### PR TITLE
Corrección de Link de Descarga y Shipping Amount

### DIFF
--- a/app/code/local/Facturacom/Facturacion/Helper/Order.php
+++ b/app/code/local/Facturacom/Facturacion/Helper/Order.php
@@ -116,7 +116,7 @@ class Facturacom_Facturacion_Helper_Order extends Mage_Core_Helper_Abstract
                 'name'  => $orderData['shipping_description'],
                 'qty'   => 1,
                 'base_price' => $orderData['shipping_amount'],
-                'price' => $orderData['shipping_amount'] + $orderData['shipping_tax_amount'],
+                'price' => $orderData['shipping_amount'], // + $orderData['shipping_tax_amount'],
                 'discount' => 0,
                 'shipping' => true,
             );

--- a/skin/frontend/base/default/facturacom/js/functions.js
+++ b/skin/frontend/base/default/facturacom/js/functions.js
@@ -634,8 +634,8 @@ $jq(function() {
           $jq('#btn-success-pdf').stop().hide();
           $jq('#btn-success-xml').stop().hide();
       }else{
-        $jq('#btn-success-pdf').stop().show().attr('href','https://factura.com/api/publica/invoice/'+response.data.invoice.uid+'/pdf');
-        $jq('#btn-success-xml').stop().show().attr('href','https://factura.com/api/publica/invoice/'+response.data.invoice.uid+'/xml');
+        $jq('#btn-success-pdf').stop().show().attr('href','https://factura.com/api/v3/cfdi33/'+response.data.invoice.uid+'/pdf');
+        $jq('#btn-success-xml').stop().show().attr('href','https://factura.com/api/v3/cfdi33/'+response.data.invoice.uid+'/xml');
       }
 
       $jq("#step-four").stop().fadeIn("slow");


### PR DESCRIPTION
- Se corrige el error en la descarga de PDF y XML.

- Se quita el _tax_amount_ del precio unitario del envío, para calcular bien el IVA.
